### PR TITLE
feat: Initialize Deno monorepo for Neem email client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
 # Neem
-A neat email client that's a pwa.
+
+A neat email client that's a PWA, built with Deno and a plugin-based architecture.
+
+## Project Structure
+
+The project is a monorepo managed with Deno. All packages are located in the `packages/` directory.
+
+- `deno.json`: Contains Deno configurations for linting, formatting, tasks, and import maps.
+- `packages/`: Directory containing all the project's packages.
+
+## Available Packages
+
+The following packages are part of this monorepo under the `@neem` scope:
+
+-   `@neem/client-ui`: Handles the client-side user interface.
+-   `@neem/service-worker`: Manages the service worker for PWA functionalities.
+-   `@neem/server`: Contains the server-side logic.
+-   `@neem/library`: Shared utilities and functions.
+-   `@neem/types`: TypeScript type definitions used across the project.
+-   `@neem/plugins`: Core plugin infrastructure and plugin management.
+
+Each package has a `mod.ts` as its main entry point and `mod.test.ts` for its unit tests.
+
+## Development
+
+### Setup
+
+Ensure you have Deno installed. Visit [https://deno.land/](https://deno.land/) for installation instructions.
+
+### Common Tasks
+
+The following tasks are defined in `deno.json` and can be run using `deno task <task-name>`:
+
+-   `check`: Runs formatter checks, linter, and all tests.
+-   `test`: Runs all tests for all packages and generates a coverage report in `cov_report/`.
+-   `bundle`: Bundles all packages. Output files will be in the `dist/` directory.
+
+### Package-Specific Tasks
+
+You can also run tests and bundle individual packages:
+
+-   `test-<package-name>`: Runs tests for a specific package (e.g., `deno task test-client-ui`). Coverage reports are generated in `cov_report_<package_name>/`.
+-   `bundle-<package-name>`: Bundles a specific package (e.g., `deno task bundle-client-ui`). The output will be in `dist/<package-name>.js`.
+
+Replace `<package-name>` with the actual package name (e.g., `client-ui`, `service-worker`).
+
+### Linting and Formatting
+
+-   To check formatting: `deno fmt --check`
+-   To format files: `deno fmt`
+-   To lint files: `deno lint`
+
+These are also part of the `check` task.

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,45 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "npm:preact"
+  },
+  "lint": {
+    "rules": {
+      "tags": [
+        "recommended"
+      ],
+      "include": [],
+      "exclude": [
+        "require-await"
+      ]
+    }
+  },
+  "fmt": {
+    "options": {
+      "useTabs": true,
+      "lineWidth": 80,
+      "indentWidth": 4,
+      "singleQuote": false
+    }
+  },
+  "tasks": {
+    "check": "deno fmt --check && deno lint && deno task test",
+    "test": "deno test --coverage=cov_report packages/*/mod.test.ts",
+    "bundle": "deno task bundle-client-ui && deno task bundle-service-worker && deno task bundle-server && deno task bundle-library && deno task bundle-types && deno task bundle-plugins",
+    "test-client-ui": "deno test --coverage=cov_report_client_ui packages/client-ui/mod.test.ts",
+    "bundle-client-ui": "deno bundle packages/client-ui/mod.ts ./dist/client-ui.js",
+    "test-service-worker": "deno test --coverage=cov_report_service_worker packages/service-worker/mod.test.ts",
+    "bundle-service-worker": "deno bundle packages/service-worker/mod.ts ./dist/service-worker.js",
+    "test-server": "deno test --coverage=cov_report_server packages/server/mod.test.ts",
+    "bundle-server": "deno bundle packages/server/mod.ts ./dist/server.js",
+    "test-library": "deno test --coverage=cov_report_library packages/library/mod.test.ts",
+    "bundle-library": "deno bundle packages/library/mod.ts ./dist/library.js",
+    "test-types": "deno test --coverage=cov_report_types packages/types/mod.test.ts",
+    "bundle-types": "deno bundle packages/types/mod.ts ./dist/types.js",
+    "test-plugins": "deno test --coverage=cov_report_plugins packages/plugins/mod.test.ts",
+    "bundle-plugins": "deno bundle packages/plugins/mod.ts ./dist/plugins.js"
+  },
+  "imports": {
+    "@neem/": "./packages/"
+  }
+}

--- a/packages/client-ui/mod.test.ts
+++ b/packages/client-ui/mod.test.ts
@@ -1,0 +1,6 @@
+import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as clientUi from "./mod.ts";
+
+Deno.test("client-ui name", () => {
+  assertEquals(clientUi.name, "@neem/client-ui");
+});

--- a/packages/client-ui/mod.ts
+++ b/packages/client-ui/mod.ts
@@ -1,0 +1,2 @@
+// client-ui package
+export const name = "@neem/client-ui";

--- a/packages/library/mod.test.ts
+++ b/packages/library/mod.test.ts
@@ -1,0 +1,6 @@
+import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as library from "./mod.ts";
+
+Deno.test("library name", () => {
+  assertEquals(library.name, "@neem/library");
+});

--- a/packages/library/mod.ts
+++ b/packages/library/mod.ts
@@ -1,0 +1,2 @@
+// library package
+export const name = "@neem/library";

--- a/packages/plugins/mod.test.ts
+++ b/packages/plugins/mod.test.ts
@@ -1,0 +1,6 @@
+import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as plugins from "./mod.ts";
+
+Deno.test("plugins name", () => {
+  assertEquals(plugins.name, "@neem/plugins");
+});

--- a/packages/plugins/mod.ts
+++ b/packages/plugins/mod.ts
@@ -1,0 +1,2 @@
+// plugins package
+export const name = "@neem/plugins";

--- a/packages/server/mod.test.ts
+++ b/packages/server/mod.test.ts
@@ -1,0 +1,6 @@
+import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as server from "./mod.ts";
+
+Deno.test("server name", () => {
+  assertEquals(server.name, "@neem/server");
+});

--- a/packages/server/mod.ts
+++ b/packages/server/mod.ts
@@ -1,0 +1,2 @@
+// server package
+export const name = "@neem/server";

--- a/packages/service-worker/mod.test.ts
+++ b/packages/service-worker/mod.test.ts
@@ -1,0 +1,6 @@
+import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as serviceWorker from "./mod.ts";
+
+Deno.test("service-worker name", () => {
+  assertEquals(serviceWorker.name, "@neem/service-worker");
+});

--- a/packages/service-worker/mod.ts
+++ b/packages/service-worker/mod.ts
@@ -1,0 +1,2 @@
+// service-worker package
+export const name = "@neem/service-worker";

--- a/packages/types/mod.test.ts
+++ b/packages/types/mod.test.ts
@@ -1,0 +1,6 @@
+import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as types from "./mod.ts";
+
+Deno.test("types name", () => {
+  assertEquals(types.name, "@neem/types");
+});

--- a/packages/types/mod.ts
+++ b/packages/types/mod.ts
@@ -1,0 +1,2 @@
+// types package
+export const name = "@neem/types";


### PR DESCRIPTION
I've set up a TypeScript-based Deno monorepo with the following structure and configurations:

- **Deno Configuration (`deno.json`):**
  - Configured for JSX (Preact), linting, and formatting.
  - Includes global tasks:
    - `check`: Runs formatter, linter, and all tests.
    - `test`: Runs all package tests with coverage.
    - `bundle`: Bundles all packages.
  - Import map for `@neem/` scope.

- **Packages:**
  I created the following packages under `packages/` with the `@neem` scope. Each package includes a `mod.ts` and a basic `mod.test.ts`:
  - `@neem/client-ui`
  - `@neem/service-worker`
  - `@neem/server`
  - `@neem/library`
  - `@neem/types`
  - `@neem/plugins`

- **Package Scripts:**
  I added individual `test-<package-name>` and `bundle-<package-name>` tasks to `deno.json` for each package. Bundled outputs are placed in the `dist/` directory.

- **README (`README.md`):**
  I updated this with detailed information about the project structure, available packages, setup instructions, and how to run development tasks (linting, formatting, testing, bundling).

This foundational setup provides a scalable structure for developing the Neem PWA email client with a plugin-based architecture.